### PR TITLE
Simplify library initialization and cleanup with automatic shutdown

### DIFF
--- a/include/sslpkix/sslpkix.h
+++ b/include/sslpkix/sslpkix.h
@@ -11,9 +11,25 @@
 
 namespace sslpkix {
 
-bool startup(void);
-void shutdown(void);
-bool seed_prng(void);
-bool add_custom_object(const char *oid, const char *sn, const char *ln, int *out_nid);
+/**
+ * @brief Initialize the SSLPKIX library.
+ * @note You MUST call this function before using any other functions in the SSLPKIX library.
+ */
+void initialize(void);
+
+/**
+ * @brief Seed the PRNG.
+ */
+void seed_prng(void);
+
+/**
+ * @brief Add a custom object to the SSLPKIX library.
+ * @param oid The OID of the custom object.
+ * @param sn The short name of the custom object.
+ * @param ln The long name of the custom object.
+ * @param alias_nid The NID of the alias for the custom object. If 0 (NID_undef), no alias is added.
+ * @return The NID of the registered custom object.
+ */
+int add_custom_object(const char *oid, const char *sn, const char *ln, int alias_nid = NID_netscape_comment);
 
 } // namespace sslpkix

--- a/test/test_cert_name_extensions.cpp
+++ b/test/test_cert_name_extensions.cpp
@@ -30,9 +30,9 @@ struct FileScopedListenerCertNameExtensions :  Catch::EventListenerBase {
     void testRunStarting(Catch::TestRunInfo const& testRunInfo) override {
         std::cout << "Running once before tests in this file: " << testRunInfo.name << std::endl;
 
-		// Add a custom extension
-		REQUIRE(sslpkix::add_custom_object(OID_clientToken, SN_clientToken, LN_clientToken, &nid_clientToken));
-		REQUIRE(sslpkix::add_custom_object(OID_usersLimit, SN_usersLimit, LN_usersLimit, &nid_usersLimit));
+		// Add custom extensions
+		nid_clientToken = sslpkix::add_custom_object(OID_clientToken, SN_clientToken, LN_clientToken);
+		nid_usersLimit = sslpkix::add_custom_object(OID_usersLimit, SN_usersLimit, LN_usersLimit);
     }
 };
 

--- a/test/test_runner.cpp
+++ b/test/test_runner.cpp
@@ -5,22 +5,11 @@
 
 struct TestRunnerSetup {
     TestRunnerSetup() {
-        bool success = sslpkix::startup();
-        if (!success) {
-            std::cerr << "ERROR: Failed to initialize SSLPKIX" << std::endl;
-            exit(EXIT_FAILURE);
-        }
-
-        success = sslpkix::seed_prng();
-        if (!success) {
-            std::cerr << "ERROR: Failed to seed the PRNG" << std::endl;
-            exit(EXIT_FAILURE);
-        }
+        sslpkix::initialize();
+        sslpkix::seed_prng();
     }
 
-    ~TestRunnerSetup() {
-        sslpkix::shutdown();
-    }
+    ~TestRunnerSetup() = default;
 };
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
The library now automatically invokes sslpkix::shutdown using atexit, eliminating the need for users to manually call cleanup functions. This simplifies the API and prevents potential resource leaks.