### PR TITLE
Fix potential memory leaks and improve ownership semantics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ file(GLOB_RECURSE TEST_SOURCES "${TEST_DIR}/*.c" "${TEST_DIR}/*.cpp")
 
 # Compiler flags
 set(CMAKE_C_STANDARD 17)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # Build type specific compile options - cross-platform
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,12 +438,23 @@ if(TEST_SOURCES)
     endif()
 
     # Custom target to run tests (matching original Makefile behavior)
-    add_custom_target(test-run
-        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/${TESTNAME}
-        DEPENDS ${TESTNAME}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMENT "Running tests with Catch2"
-    )
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND UNIX AND NOT APPLE AND NOT WIN32)
+        # Configure LeakSanitizer on Unix-like systems (excluding macOS)
+        add_custom_target(test-run
+            COMMAND ${CMAKE_COMMAND} -E env "ASAN_OPTIONS=detect_leaks=1:fast_unwind_on_malloc=0:verbosity=2:malloc_context_size=30"
+                    ${CMAKE_CURRENT_BINARY_DIR}/build/${TESTNAME}
+            DEPENDS ${TESTNAME}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMENT "Running tests with Catch2 (with LeakSanitizer)"
+        )
+    else()
+        add_custom_target(test-run
+            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/${TESTNAME}
+            DEPENDS ${TESTNAME}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMENT "Running tests with Catch2"
+        )
+    endif()
 
     # Add convenience target that matches the test Makefile
     add_custom_target(build-binary

--- a/include/sslpkix/resource_ownership.h
+++ b/include/sslpkix/resource_ownership.h
@@ -11,7 +11,7 @@ enum class ResourceOwnership : unsigned int {
     Transfer = 1, // Takes ownership of the resource. The resource will be freed when the object is destroyed.
 };
 
-constexpr bool should_own_resource(ResourceOwnership value) noexcept {
+inline constexpr bool should_own_resource(ResourceOwnership value) noexcept {
     return value == ResourceOwnership::Transfer;
 }
 

--- a/include/sslpkix/resource_ownership.h
+++ b/include/sslpkix/resource_ownership.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace sslpkix {
+
+/**
+ * @brief ResourceOwnership enum class defines options for ownership management.
+ * It can be used to control whether a resource should be freed or not when the object is destroyed.
+ */
+enum class ResourceOwnership : unsigned int {
+    Default = 0, // Default behavior, does not take ownership. The resource will not be freed when the object is destroyed.
+    Transfer = 1, // Takes ownership of the resource. The resource will be freed when the object is destroyed.
+};
+
+constexpr bool should_own_resource(ResourceOwnership value) noexcept {
+    return value == ResourceOwnership::Transfer;
+}
+
+} // namespace sslpkix

--- a/include/sslpkix/x509/cert.h
+++ b/include/sslpkix/x509/cert.h
@@ -428,7 +428,7 @@ public:
         if (!duplicated) {
             throw error::cert::RuntimeError("Failed to duplicate subject name");
         }
-        return CertificateName{duplicated}; // Takes ownership
+        return CertificateName{duplicated}; // Takes ownership by default
     }
 
     CertificateName subject() {
@@ -441,7 +441,7 @@ public:
         if (!duplicated) {
             throw error::cert::RuntimeError("Failed to duplicate subject name");
         }
-        return CertificateName{duplicated}; // Takes ownership
+        return CertificateName{duplicated}; // Takes ownership by default
     }
 
     void set_issuer(const CertificateName& issuer) {
@@ -467,7 +467,7 @@ public:
         if (!duplicated) {
             throw error::cert::RuntimeError("Failed to duplicate issuer name");
         }
-        return CertificateName{duplicated}; // Takes ownership
+        return CertificateName{duplicated}; // Takes ownership by default
     }
 
     CertificateName issuer() {
@@ -480,7 +480,7 @@ public:
         if (!duplicated) {
             throw error::cert::RuntimeError("Failed to duplicate issuer name");
         }
-        return CertificateName{duplicated}; // Takes ownership
+        return CertificateName{duplicated}; // Takes ownership by default
     }
 
     bool verify_signature(const Key& key) const {

--- a/include/sslpkix/x509/cert.h
+++ b/include/sslpkix/x509/cert.h
@@ -59,7 +59,26 @@ public:
         _handle.reset(new_cert);
     }
 
-    // Constructor for creating certificate from existing X509 handle
+    /**
+     * @brief This constructor initializes a Certificate object using an existing X509 handle.
+     * It takes ownership and manages the handle using a smart pointer.
+     *
+     * @throw error::cert::InvalidArgumentError if the provided handle is null.
+     * @param cert_handle The existing X509 handle to wrap.
+     *
+     * @note The handle is expected to be a valid X509 certificate, and it
+     *       should not be used after passing it to this constructor, as the Certificate
+     *       object will take ownership of it and manage its lifetime.
+     * @note This constructor does not check if the certificate has all required fields.
+     *       It is the caller's responsibility to ensure that the certificate is valid and has
+     *       the necessary fields set before passing it to this constructor.
+     *       If you need to check the validity of the certificate, use the `has_required_fields()`
+     *       method after constructing the Certificate object.
+     * @note This constructor does not perform any validation on the provided X509 handle.
+     *       It is the caller's responsibility to ensure that the handle is a valid X509 certificate.
+     *       If the handle is not a valid X509 certificate, it may lead to undefined behavior
+     *       when using the Certificate object.
+     */
     explicit Certificate(X509* cert_handle) {
         if (!cert_handle) {
             throw error::cert::InvalidArgumentError("Certificate handle cannot be null");

--- a/include/sslpkix/x509/cert.h
+++ b/include/sslpkix/x509/cert.h
@@ -447,7 +447,7 @@ public:
         if (!duplicated) {
             throw error::cert::RuntimeError("Failed to duplicate subject name");
         }
-        return CertificateName{duplicated}; // Takes ownership by default
+        return CertificateName{duplicated, ResourceOwnership::Transfer};
     }
 
     CertificateName subject() {
@@ -460,7 +460,7 @@ public:
         if (!duplicated) {
             throw error::cert::RuntimeError("Failed to duplicate subject name");
         }
-        return CertificateName{duplicated}; // Takes ownership by default
+        return CertificateName{duplicated, ResourceOwnership::Transfer};
     }
 
     void set_issuer(const CertificateName& issuer) {
@@ -486,7 +486,7 @@ public:
         if (!duplicated) {
             throw error::cert::RuntimeError("Failed to duplicate issuer name");
         }
-        return CertificateName{duplicated}; // Takes ownership by default
+        return CertificateName{duplicated, ResourceOwnership::Transfer};
     }
 
     CertificateName issuer() {
@@ -499,7 +499,7 @@ public:
         if (!duplicated) {
             throw error::cert::RuntimeError("Failed to duplicate issuer name");
         }
-        return CertificateName{duplicated}; // Takes ownership by default
+        return CertificateName{duplicated, ResourceOwnership::Transfer};
     }
 
     bool verify_signature(const Key& key) const {

--- a/include/sslpkix/x509/cert_name.h
+++ b/include/sslpkix/x509/cert_name.h
@@ -53,11 +53,16 @@ public:
     }
 
     /**
-     * @brief Constructor for external handle (does not create new name)
-     * @note 1. Does not increment reference count
-     * @note 2. Does not take ownership
+     * @brief This constructor initializes a CertificateName object using an existing X509_NAME handle.
+     * It optionally transfers ownership of the handle, managing its lifecycle with a custom deleter.
+     *
+     * @param external_handle The existing X509_NAME handle to wrap. If you pass a null handle, it will create an empty CertificateName.
+     * @param transfer_ownership If true, the CertificateName will take ownership of the handle
+     *
+     * @throws `error::cert_name::BadAllocError` if the handle is null and transfer_ownership is true
+     * @throws `std::runtime_error` if the handle is null and transfer_ownership is false
      */
-    explicit CertificateName(X509_NAME* external_handle) : handle_(external_handle, Deleter{false}) {}
+    explicit CertificateName(X509_NAME* external_handle, bool transfer_ownership = true) : handle_(external_handle, Deleter{transfer_ownership}) {}
 
     // Copy constructor - deep copy
     CertificateName(const CertificateName& other) {

--- a/include/sslpkix/x509/cert_name.h
+++ b/include/sslpkix/x509/cert_name.h
@@ -322,6 +322,7 @@ public:
             unsigned char* enc2 = nullptr;
             int len2 = i2d_X509_NAME(rhs.handle_.get(), &enc2);
             if (len2 < 0) {
+                OPENSSL_free(enc1);
                 throw error::cert_name::RuntimeError("Failed to encode rhs certificate name");
             }
 

--- a/include/sslpkix/x509/cert_name.h
+++ b/include/sslpkix/x509/cert_name.h
@@ -9,6 +9,7 @@
 #include <openssl/bio.h>
 #include "sslpkix/bio_wrapper.h"
 #include "sslpkix/exception.h"
+#include "sslpkix/resource_ownership.h"
 
 namespace sslpkix {
 
@@ -54,15 +55,12 @@ public:
 
     /**
      * @brief This constructor initializes a CertificateName object using an existing X509_NAME handle.
-     * It optionally transfers ownership of the handle, managing its lifecycle with a custom deleter.
+     * It optionally transfers ownership of the handle, managing its lifecycle with a custom deleter based on the specified ResourceOwnership.
      *
      * @param external_handle The existing X509_NAME handle to wrap. If you pass a null handle, it will create an empty CertificateName.
-     * @param transfer_ownership If true, the CertificateName will take ownership of the handle
-     *
-     * @throws `error::cert_name::BadAllocError` if the handle is null and transfer_ownership is true
-     * @throws `std::runtime_error` if the handle is null and transfer_ownership is false
+     * @param ownership The ownership semantics for the handle. If set to `ResourceOwnership::Transfer`, the CertificateName will take ownership of the handle and free it when destroyed.
      */
-    explicit CertificateName(X509_NAME* external_handle, bool transfer_ownership = true) : handle_(external_handle, Deleter{transfer_ownership}) {}
+    explicit CertificateName(X509_NAME* external_handle, const ResourceOwnership ownership) noexcept : handle_(external_handle, Deleter{should_own_resource(ownership)}) {}
 
     // Copy constructor - deep copy
     CertificateName(const CertificateName& other) {

--- a/include/sslpkix/x509/cert_req.h
+++ b/include/sslpkix/x509/cert_req.h
@@ -258,7 +258,7 @@ public:
         if (!duplicated) {
             throw error::cert_req::RuntimeError("Failed to duplicate subject name");
         }
-        return CertificateName{duplicated}; // Takes ownership
+        return CertificateName{duplicated}; // Takes ownership by default
     }
 
     CertificateName subject() {
@@ -271,7 +271,7 @@ public:
         if (!duplicated) {
             throw error::cert_req::RuntimeError("Failed to duplicate subject name");
         }
-        return CertificateName{duplicated}; // Takes ownership
+        return CertificateName{duplicated}; // Takes ownership by default
     }
 
     // Verify signature

--- a/include/sslpkix/x509/cert_req.h
+++ b/include/sslpkix/x509/cert_req.h
@@ -258,7 +258,7 @@ public:
         if (!duplicated) {
             throw error::cert_req::RuntimeError("Failed to duplicate subject name");
         }
-        return CertificateName{duplicated}; // Takes ownership by default
+        return CertificateName{duplicated, ResourceOwnership::Transfer};
     }
 
     CertificateName subject() {
@@ -271,7 +271,7 @@ public:
         if (!duplicated) {
             throw error::cert_req::RuntimeError("Failed to duplicate subject name");
         }
-        return CertificateName{duplicated}; // Takes ownership by default
+        return CertificateName{duplicated, ResourceOwnership::Transfer};
     }
 
     // Verify signature

--- a/include/sslpkix/x509/key.h
+++ b/include/sslpkix/x509/key.h
@@ -299,9 +299,6 @@ namespace traits {
     };
 } // namespace traits
 
-// Forward declaration of PrivateKey
-class PrivateKey;
-
 //
 // NOTE: With OpenSSL, the private key also contains the public key information
 //
@@ -569,20 +566,10 @@ public:
     }
 
     /**
-     * @brief Returns the public key (only) from a private key.
+     * @brief Returns a public key from a private key.
      * @note This is a convenience method that extracts the public key from the private key.
-     * @return A unique_ptr to a Key object containing only the public key.
      */
     std::unique_ptr<Key> pubkey() const;
-
-    /**
-     * @brief Casts the key to a private key.
-     * @note This is a convenience method that returns a unique_ptr to a PrivateKey object.
-     * @return A unique_ptr to a PrivateKey object containing the original key material, which may contain the public key.
-     */
-    std::unique_ptr<PrivateKey> privkey() const {
-        return std::make_unique<PrivateKey>(_handle.get());
-    }
 
 protected:
     /**

--- a/include/sslpkix/x509/key.h
+++ b/include/sslpkix/x509/key.h
@@ -566,7 +566,10 @@ public:
     }
 
     /**
-     * @brief Returns a public key from a private key.
+     * @brief Returns the public key (only) from a private key.
+     *
+     * @return A unique_ptr to a Key object containing only the public key.
+     *
      * @note This is a convenience method that extracts the public key from the private key.
      */
     std::unique_ptr<Key> pubkey() const;

--- a/include/sslpkix/x509/key.h
+++ b/include/sslpkix/x509/key.h
@@ -331,7 +331,19 @@ public:
 protected:
     detail::handle_ptr _handle{nullptr, detail::EVP_PKEY_Deleter()};
 
-    // Protected constructor for creating empty key (used by derived classes)
+    /**
+     * @brief This constructor is a protected, explicit, and inline constructor used for creating an empty key, primarily
+     * intended for use by derived classes. If the `create_handle` parameter is true, it initializes a new key by invoking
+     * `create_new_key()` and assigns a unique `key_id` using a static counter.
+     *
+     * @param create_handle If true, a new key is created; otherwise, the key is left uninitialized.
+     *
+     * @throws `error::key::BadAllocError` if the key creation fails.
+     *
+     * @note 1. This constructor is not intended for direct use outside of the class hierarchy.
+     * @note 2. The `key_id` is assigned a unique value from a static counter to uniquely identify each key instance.
+     * @note 3. This constructor is used to create a new key when the `Key` object is instantiated without any parameters or when a new key is explicitly requested.
+     */
     explicit Key(bool create_handle) {
         if (create_handle) {
             create_new_key();
@@ -354,10 +366,18 @@ protected:
     static int static_key_counter;
 
 public:
-    // Default constructor - creates a new key
+    /**
+     * @brief This inline default constructor initializes a new key by delegating to another constructor with a true argument.
+     * It simplifies the creation of a key with default behavior.
+     */
     Key() : Key(true) {}
 
-    // Constructor for external handle (does not create new key)
+    /**
+     * @brief This constructor initializes a Key object using an external EVP_PKEY handle without creating a new key.
+     * It assigns a unique key ID and sets the external handle.
+     *
+     * @param external_handle The existing EVP_PKEY handle to wrap.
+     */
     explicit Key(EVP_PKEY* external_handle) {
         key_id = static_key_counter++;
         // auto provider = EVP_PKEY_get0_provider(external_handle);
@@ -576,10 +596,14 @@ public:
 
 protected:
     /**
-     * @brief Set the external handle object
-     * @note This method increments the reference count of the existing key so it can be safely used and free'd elsewhere.
+     * @brief Sets an external EVP_PKEY handle for the key. It increments the reference count of the provided handle,
+     * throws a runtime error if the increment fails, and resets the internal handle to the provided one or clears it if the input is null.
+     * This allows the Key object to manage an external key without taking ownership of it.
+     * This is useful when you want to use an existing key without duplicating it.
      *
-     * @param handle
+     * @param handle The external EVP_PKEY handle to set.
+     *
+     * @note This method increments the reference count of the existing key so it can be safely used and free'd elsewhere.
      */
     void set_external_handle(EVP_PKEY* handle) {
         if (!handle) {

--- a/src/sslpkix.cpp
+++ b/src/sslpkix.cpp
@@ -23,6 +23,7 @@ void cleanup(void) {
 		OSSL_PROVIDER_unload(g_provider);
 		g_provider = nullptr;
 	}
+	// The OPENSSL_cleanup() function deinitialises OpenSSL (both libcrypto and libssl)
 	OPENSSL_cleanup();
 }
 

--- a/src/x509/key.cpp
+++ b/src/x509/key.cpp
@@ -44,6 +44,8 @@ std::unique_ptr<Key> Key::pubkey() const {
         if (!OSSL_PARAM_BLD_push_BN(params_builder.get(), OSSL_PKEY_PARAM_RSA_N, n) ||
             !OSSL_PARAM_BLD_push_BN(params_builder.get(), OSSL_PKEY_PARAM_RSA_E, e))
         {
+            BN_free(n);
+            BN_free(e);
             throw error::key::RuntimeError("Failed on OSSL_PARAM_BLD_push_*");
         }
 

--- a/src/x509/key.cpp
+++ b/src/x509/key.cpp
@@ -116,7 +116,7 @@ std::unique_ptr<Key> Key::pubkey() const {
         throw error::key::RuntimeError("Failed on EVP_PKEY_fromdata");
     }
 
-    return std::make_unique<Key>(new_pub_key);
+    return std::make_unique<Key>(new_pub_key, ResourceOwnership::Transfer);
 }
 
 namespace factory {

--- a/test/test_cert.cpp
+++ b/test/test_cert.cpp
@@ -82,12 +82,12 @@ TEST_CASE_METHOD(CertificateTestFixture, "Certificate Construction", "[certifica
         X509* x509 = X509_new();
         REQUIRE(x509 != nullptr);
 
-        Certificate cert(x509); // Ownership is transferred to Certificate
+        Certificate cert(x509, ResourceOwnership::Transfer);
         REQUIRE(cert.handle() == x509);
     }
 
     SECTION("Constructor with null handle throws") {
-        REQUIRE_THROWS_AS(Certificate(nullptr), std::invalid_argument);
+        REQUIRE_THROWS_AS(Certificate(nullptr, ResourceOwnership::Transfer), std::invalid_argument);
     }
 }
 

--- a/test/test_cert.cpp
+++ b/test/test_cert.cpp
@@ -44,7 +44,7 @@ private:
 
     void createTestKeyPair() {
         EVP_PKEY* private_pkey = factory::generate_key_rsa(512);
-        test_private_key = std::make_unique<PrivateKey>(private_pkey);
+        test_private_key = std::make_unique<PrivateKey>(private_pkey, ResourceOwnership::Transfer);
         test_public_key = test_private_key->pubkey();
     }
 

--- a/test/test_cert.cpp
+++ b/test/test_cert.cpp
@@ -43,8 +43,8 @@ protected:
 private:
 
     void createTestKeyPair() {
-        auto keypair = factory::generate_key_rsa(512);
-        test_private_key = Key(keypair).privkey();
+        EVP_PKEY* private_pkey = factory::generate_key_rsa(512);
+        test_private_key = std::make_unique<PrivateKey>(private_pkey);
         test_public_key = test_private_key->pubkey();
     }
 

--- a/test/test_cert_name.cpp
+++ b/test/test_cert_name.cpp
@@ -61,15 +61,20 @@ TEST_CASE_METHOD(CertificateNameTestFixture, "CertificateName creation and basic
 
 TEST_CASE_METHOD(CertificateNameTestFixture, "CertificateName handle constructor", "[CertificateName][constructor]") {
 	SECTION("Valid handle construction") {
-		X509_NAME* raw_name = X509_NAME_new();
-		REQUIRE(raw_name != nullptr);
+		X509_NAME* raw_name1 = X509_NAME_new();
+		REQUIRE(raw_name1 != nullptr);
+		CertificateName managed_name(raw_name1); // Takes ownership by default
+		REQUIRE(managed_name);
+		REQUIRE(managed_name.handle() == raw_name1);
 
-		CertificateName name(raw_name);
-		REQUIRE(name);
-		REQUIRE(name.handle() == raw_name);
+		X509_NAME* raw_name2 = X509_NAME_new();
+		REQUIRE(raw_name2 != nullptr);
+		CertificateName unmanaged_name(raw_name2, false); // Does not take ownership
+		REQUIRE(unmanaged_name);
+		REQUIRE(unmanaged_name.handle() == raw_name2);
 
 		// Cleanup the handle
-		X509_NAME_free(raw_name);
+		X509_NAME_free(raw_name2);
 	}
 
 	SECTION("Null handle does not throw exception") {

--- a/test/test_cert_name.cpp
+++ b/test/test_cert_name.cpp
@@ -63,13 +63,13 @@ TEST_CASE_METHOD(CertificateNameTestFixture, "CertificateName handle constructor
 	SECTION("Valid handle construction") {
 		X509_NAME* raw_name1 = X509_NAME_new();
 		REQUIRE(raw_name1 != nullptr);
-		CertificateName managed_name(raw_name1); // Takes ownership by default
+		CertificateName managed_name(raw_name1, ResourceOwnership::Transfer);
 		REQUIRE(managed_name);
 		REQUIRE(managed_name.handle() == raw_name1);
 
 		X509_NAME* raw_name2 = X509_NAME_new();
 		REQUIRE(raw_name2 != nullptr);
-		CertificateName unmanaged_name(raw_name2, false); // Does not take ownership
+		CertificateName unmanaged_name(raw_name2, ResourceOwnership::Default);
 		REQUIRE(unmanaged_name);
 		REQUIRE(unmanaged_name.handle() == raw_name2);
 
@@ -78,11 +78,11 @@ TEST_CASE_METHOD(CertificateNameTestFixture, "CertificateName handle constructor
 	}
 
 	SECTION("Null handle does not throw exception") {
-		REQUIRE_NOTHROW(CertificateName(nullptr));
+		REQUIRE_NOTHROW(CertificateName(nullptr, ResourceOwnership::Transfer));
 	}
 
 	SECTION("Constructing with null handle") {
-		CertificateName null_name(nullptr);
+		CertificateName null_name(nullptr, ResourceOwnership::Transfer);
 		REQUIRE_FALSE(null_name);
 		REQUIRE(null_name.handle() == nullptr);
 		REQUIRE_FALSE(null_name.has_handle());

--- a/test/test_cert_req.cpp
+++ b/test/test_cert_req.cpp
@@ -71,7 +71,7 @@ TEST_CASE_METHOD(CertificateRequestTestFixture, "CertificateRequest Copy Operati
     CertificateName subject = create_certificate_name();
 
     EVP_PKEY* keypair = create_keypair();
-    std::unique_ptr<PrivateKey> private_key = Key(keypair).privkey();
+    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair);
     std::unique_ptr<Key> public_key = private_key->pubkey();
 
     REQUIRE(original.set_version(CertificateRequest::Version::v1));
@@ -149,7 +149,7 @@ TEST_CASE_METHOD(CertificateRequestTestFixture, "CertificateRequest Public Key O
 
     // Test data members
     EVP_PKEY* keypair = create_keypair();
-    std::unique_ptr<PrivateKey> private_key = Key(keypair).privkey();
+    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair);
     std::unique_ptr<Key> public_key = private_key->pubkey();
 
     SECTION("Set and get public key") {
@@ -188,7 +188,7 @@ TEST_CASE_METHOD(CertificateRequestTestFixture, "CertificateRequest Signing Oper
     CertificateName subject = create_certificate_name();
 
     EVP_PKEY* keypair = create_keypair();
-    std::unique_ptr<PrivateKey> private_key = Key(keypair).privkey();
+    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair);
     std::unique_ptr<Key> public_key = private_key->pubkey();
 
     REQUIRE(req.set_version(CertificateRequest::Version::v1));
@@ -248,7 +248,7 @@ TEST_CASE("CertificateRequest Extensions", "[certificate_request][extensions]") 
 
 TEST_CASE_METHOD(CertificateRequestTestFixture, "CertificateRequest Verification Operations", "[certificate_request][verification]") {
     EVP_PKEY* keypair = create_keypair();
-    std::unique_ptr<PrivateKey> private_key = Key(keypair).privkey();
+    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair);
     std::unique_ptr<Key> public_key = private_key->pubkey();
 
     CertificateName subject = create_certificate_name();
@@ -278,7 +278,7 @@ TEST_CASE_METHOD(CertificateRequestTestFixture, "CertificateRequest IO Operation
     CertificateName subject = create_certificate_name();
 
     EVP_PKEY* keypair = create_keypair();
-    std::unique_ptr<PrivateKey> private_key = Key(keypair).privkey();
+    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair);
     std::unique_ptr<Key> public_key = private_key->pubkey();
 
     REQUIRE_NOTHROW(req.set_version(CertificateRequest::Version::v1));
@@ -336,7 +336,7 @@ TEST_CASE_METHOD(CertificateRequestTestFixture, "CertificateRequest Complete Wor
         CertificateName subject = create_certificate_name();
 
         EVP_PKEY* keypair = create_keypair();
-        std::unique_ptr<PrivateKey> private_key = Key(keypair).privkey();
+        std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair);
         std::unique_ptr<Key> public_key = private_key->pubkey();
 
         // Step 1: Set version
@@ -369,7 +369,7 @@ TEST_CASE_METHOD(CertificateRequestTestFixture, "CertificateRequest Error Handli
         CertificateName subject = create_certificate_name();
 
         EVP_PKEY* keypair = create_keypair();
-        std::unique_ptr<PrivateKey> private_key = Key(keypair).privkey();
+        std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair);
         std::unique_ptr<Key> public_key = private_key->pubkey();
 
         REQUIRE_FALSE(req);

--- a/test/test_cert_req.cpp
+++ b/test/test_cert_req.cpp
@@ -71,7 +71,7 @@ TEST_CASE_METHOD(CertificateRequestTestFixture, "CertificateRequest Copy Operati
     CertificateName subject = create_certificate_name();
 
     EVP_PKEY* keypair = create_keypair();
-    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair);
+    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair, ResourceOwnership::Transfer);
     std::unique_ptr<Key> public_key = private_key->pubkey();
 
     REQUIRE(original.set_version(CertificateRequest::Version::v1));
@@ -149,7 +149,7 @@ TEST_CASE_METHOD(CertificateRequestTestFixture, "CertificateRequest Public Key O
 
     // Test data members
     EVP_PKEY* keypair = create_keypair();
-    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair);
+    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair, ResourceOwnership::Transfer);
     std::unique_ptr<Key> public_key = private_key->pubkey();
 
     SECTION("Set and get public key") {
@@ -188,7 +188,7 @@ TEST_CASE_METHOD(CertificateRequestTestFixture, "CertificateRequest Signing Oper
     CertificateName subject = create_certificate_name();
 
     EVP_PKEY* keypair = create_keypair();
-    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair);
+    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair, ResourceOwnership::Transfer);
     std::unique_ptr<Key> public_key = private_key->pubkey();
 
     REQUIRE(req.set_version(CertificateRequest::Version::v1));
@@ -248,7 +248,7 @@ TEST_CASE("CertificateRequest Extensions", "[certificate_request][extensions]") 
 
 TEST_CASE_METHOD(CertificateRequestTestFixture, "CertificateRequest Verification Operations", "[certificate_request][verification]") {
     EVP_PKEY* keypair = create_keypair();
-    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair);
+    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair, ResourceOwnership::Transfer);
     std::unique_ptr<Key> public_key = private_key->pubkey();
 
     CertificateName subject = create_certificate_name();
@@ -278,7 +278,7 @@ TEST_CASE_METHOD(CertificateRequestTestFixture, "CertificateRequest IO Operation
     CertificateName subject = create_certificate_name();
 
     EVP_PKEY* keypair = create_keypair();
-    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair);
+    std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair, ResourceOwnership::Transfer);
     std::unique_ptr<Key> public_key = private_key->pubkey();
 
     REQUIRE_NOTHROW(req.set_version(CertificateRequest::Version::v1));
@@ -336,7 +336,7 @@ TEST_CASE_METHOD(CertificateRequestTestFixture, "CertificateRequest Complete Wor
         CertificateName subject = create_certificate_name();
 
         EVP_PKEY* keypair = create_keypair();
-        std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair);
+        std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair, ResourceOwnership::Transfer);
         std::unique_ptr<Key> public_key = private_key->pubkey();
 
         // Step 1: Set version
@@ -369,7 +369,7 @@ TEST_CASE_METHOD(CertificateRequestTestFixture, "CertificateRequest Error Handli
         CertificateName subject = create_certificate_name();
 
         EVP_PKEY* keypair = create_keypair();
-        std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair);
+        std::unique_ptr<PrivateKey> private_key = std::make_unique<PrivateKey>(keypair, ResourceOwnership::Transfer);
         std::unique_ptr<Key> public_key = private_key->pubkey();
 
         REQUIRE_FALSE(req);

--- a/test/test_general_1.cpp
+++ b/test/test_general_1.cpp
@@ -27,7 +27,7 @@ protected:
 		auto issuer = create_issuer();
 		auto subject = is_self_signed ? create_issuer() : create_subject();
 		auto keypair = sslpkix::factory::generate_key_rsa(512);
-		auto private_key = sslpkix::Key(keypair).privkey();
+		auto private_key = std::make_unique<sslpkix::PrivateKey>(keypair);
 		auto public_key = private_key->pubkey();
 		auto cert = create_certificate(*subject, *issuer, *public_key);
 		sign_certificate(*cert, *private_key);

--- a/test/test_general_1.cpp
+++ b/test/test_general_1.cpp
@@ -27,7 +27,7 @@ protected:
 		auto issuer = create_issuer();
 		auto subject = is_self_signed ? create_issuer() : create_subject();
 		auto keypair = sslpkix::factory::generate_key_rsa(512);
-		auto private_key = std::make_unique<sslpkix::PrivateKey>(keypair);
+		auto private_key = std::make_unique<sslpkix::PrivateKey>(keypair, sslpkix::ResourceOwnership::Transfer);
 		auto public_key = private_key->pubkey();
 		auto cert = create_certificate(*subject, *issuer, *public_key);
 		sign_certificate(*cert, *private_key);

--- a/test/test_key.cpp
+++ b/test/test_key.cpp
@@ -77,7 +77,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key assignment", "[Key][assignment]") {
     PrivateKey private_key(keypair, ResourceOwnership::Transfer);
     Key new_key;
 
-    REQUIRE_NOTHROW(new_key.assign(keypair, ResourceOwnership::Default));
+    REQUIRE_NOTHROW(new_key.assign(keypair, ResourceOwnership::Default)); // Already owned by private_key above
     REQUIRE(new_key.algorithm() == KeyType::RSA);
     REQUIRE(new_key == private_key);
     REQUIRE(new_key.has_public_key());
@@ -95,7 +95,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key RSA operations", "[Key][RSA]") {
 
     SECTION("Assign RSA keypair") {
         Key new_key;
-        REQUIRE_NOTHROW(new_key.assign(keypair, ResourceOwnership::Default));
+        REQUIRE_NOTHROW(new_key.assign(keypair, ResourceOwnership::Default)); // Already owned by private_key above
         REQUIRE(new_key.algorithm() == KeyType::RSA);
         REQUIRE(new_key == *public_key);
         REQUIRE(new_key == private_key);
@@ -115,7 +115,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key RSA operations", "[Key][RSA]") {
 
     SECTION("Assign RSA public key") {
         Key new_key;
-        REQUIRE_NOTHROW(new_key.assign(public_key->handle(), ResourceOwnership::Default));
+        REQUIRE_NOTHROW(new_key.assign(public_key->handle(), ResourceOwnership::Default)); // Already owned by pubkey_only above
         REQUIRE(new_key.algorithm() == KeyType::RSA);
         REQUIRE(new_key == *public_key);
         REQUIRE(new_key == private_key);
@@ -205,11 +205,11 @@ TEST_CASE_METHOD(KeyTestFixture, "Key comparison operators", "[Key][comparison]"
     SECTION("Different keys comparison") {
         // Copying a key should result in an equal key
         // So comparing the copied key with the original should not throw an error
-        Key copied_key1(key1.handle(), ResourceOwnership::Default);
+        Key copied_key1(key1.handle(), ResourceOwnership::Default); // Already owned by key1 above
         REQUIRE(copied_key1 == key1);
         REQUIRE_FALSE(copied_key1 != key1);
 
-        Key copied_key2(key2.handle(), ResourceOwnership::Default);
+        Key copied_key2(key2.handle(), ResourceOwnership::Default); // Already owned by key2 above
         REQUIRE(copied_key2 == key2);
         REQUIRE_FALSE(copied_key2 != key2);
 
@@ -233,7 +233,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key external handle operations", "[Key][extern
     SECTION("Assign a null external handle") {
         EVP_PKEY* external_key = nullptr;
 
-        Key new_key(external_key, ResourceOwnership::Default);
+        Key new_key(external_key, ResourceOwnership::Transfer);
         REQUIRE(new_key.handle() == nullptr);
         REQUIRE(new_key.handle() == external_key);
     }
@@ -323,7 +323,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key error conditions", "[Key][error]") {
     }
 
     SECTION("Assign null key") {
-        REQUIRE_THROWS_AS(key.assign(nullptr, ResourceOwnership::Default), error::key::InvalidArgumentError);
+        REQUIRE_THROWS_AS(key.assign(nullptr, ResourceOwnership::Transfer), error::key::InvalidArgumentError);
     }
 
     SECTION("Copy null key") {
@@ -354,7 +354,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key pubkey", "[Key][pubkey]") {
     auto keypair = sslpkix::factory::generate_key_rsa(512);
     auto private_key = std::make_unique<sslpkix::PrivateKey>(keypair, ResourceOwnership::Transfer);
     // Create a public key from the private key
-    auto public_key = std::make_unique<sslpkix::Key>(private_key->handle(), ResourceOwnership::Default);
+    auto public_key = std::make_unique<sslpkix::Key>(private_key->handle(), ResourceOwnership::Default); // Already owned by private_key above
     // Extract the public key from the private key
     auto extracted_public_key = private_key->pubkey();
 

--- a/test/test_key.cpp
+++ b/test/test_key.cpp
@@ -353,10 +353,12 @@ TEST_CASE_METHOD(KeyTestFixture, "PrivateKey error conditions", "[PrivateKey][er
 }
 
 TEST_CASE_METHOD(KeyTestFixture, "Key pubkey", "[Key][pubkey]") {
-    auto raw_keypair = sslpkix::factory::generate_key_rsa(512);
-    auto keypair = sslpkix::Key(raw_keypair);
-    auto private_key = keypair.privkey(); // Result still contains the full keypair
-    auto public_key_only = private_key->pubkey(); // Result contains only the public key
+    auto keypair = sslpkix::factory::generate_key_rsa(512);
+    auto private_key = std::make_unique<sslpkix::PrivateKey>(keypair);
+    // Create a public key from the private key
+    auto public_key = std::make_unique<sslpkix::Key>(private_key->handle());
+    // Extract the public key from the private key
+    auto extracted_public_key = private_key->pubkey();
 
     // Print the public keys to memory sinks
     MemorySink sink1, sink2;
@@ -364,8 +366,8 @@ TEST_CASE_METHOD(KeyTestFixture, "Key pubkey", "[Key][pubkey]") {
     sink2.open_rw();
 
     // Print the public keys to the memory sinks
-    keypair.print_ex(sink1.handle());
-    public_key_only->print_ex(sink2.handle());
+    public_key->print_ex(sink1.handle());
+    extracted_public_key->print_ex(sink2.handle());
 
     // Compare the printed public keys
     REQUIRE(sink1.read_all() == sink2.read_all());

--- a/test/test_key.cpp
+++ b/test/test_key.cpp
@@ -77,7 +77,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key assignment", "[Key][assignment]") {
     PrivateKey private_key(keypair, ResourceOwnership::Transfer);
     Key new_key;
 
-    REQUIRE_NOTHROW(new_key.assign(keypair));
+    REQUIRE_NOTHROW(new_key.assign(keypair, ResourceOwnership::Default));
     REQUIRE(new_key.algorithm() == KeyType::RSA);
     REQUIRE(new_key == private_key);
     REQUIRE(new_key.has_public_key());
@@ -95,7 +95,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key RSA operations", "[Key][RSA]") {
 
     SECTION("Assign RSA keypair") {
         Key new_key;
-        REQUIRE_NOTHROW(new_key.assign(keypair));
+        REQUIRE_NOTHROW(new_key.assign(keypair, ResourceOwnership::Default));
         REQUIRE(new_key.algorithm() == KeyType::RSA);
         REQUIRE(new_key == *public_key);
         REQUIRE(new_key == private_key);
@@ -115,7 +115,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key RSA operations", "[Key][RSA]") {
 
     SECTION("Assign RSA public key") {
         Key new_key;
-        REQUIRE_NOTHROW(new_key.assign(public_key->handle()));
+        REQUIRE_NOTHROW(new_key.assign(public_key->handle(), ResourceOwnership::Default));
         REQUIRE(new_key.algorithm() == KeyType::RSA);
         REQUIRE(new_key == *public_key);
         REQUIRE(new_key == private_key);
@@ -141,7 +141,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key RSA operations", "[Key][RSA]") {
 //     REQUIRE(keypair != nullptr);
 //
 //     Key key;
-//     REQUIRE_NOTHROW(key.assign(keypair));
+//     REQUIRE_NOTHROW(key.assign(keypair, ResourceOwnership::Transfer));
 //     REQUIRE(key.algorithm() == KeyType::DSA);
 // }
 // #endif
@@ -152,7 +152,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key EC operations", "[Key][EC]") {
     REQUIRE(keypair != nullptr);
 
     Key key;
-    REQUIRE_NOTHROW(key.assign(keypair));
+    REQUIRE_NOTHROW(key.assign(keypair, ResourceOwnership::Transfer));
     REQUIRE(key.algorithm() == KeyType::EC);
 }
 #endif
@@ -168,7 +168,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key bit_length method", "[Key][bit_length]") {
     SECTION("RSA key bit length") {
         auto keypair = factory::generate_key_rsa(512);
         REQUIRE(keypair != nullptr);
-        REQUIRE_NOTHROW(key.assign(keypair));
+        REQUIRE_NOTHROW(key.assign(keypair, ResourceOwnership::Transfer));
         REQUIRE(key.bit_length() == 512);
     }
     #endif
@@ -178,7 +178,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key bit_length method", "[Key][bit_length]") {
     //     auto keypair = factory::generate_key_dsa(2048, 256);
     //     REQUIRE(keypair != nullptr);
     //
-    //     REQUIRE_NOTHROW(key.assign(keypair));
+    //     REQUIRE_NOTHROW(key.assign(keypair, ResourceOwnership::Transfer));
     //     REQUIRE(key.bit_length() == 512);
     // }
     // #endif
@@ -187,7 +187,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key bit_length method", "[Key][bit_length]") {
     SECTION("EC key bit length") {
         auto keypair = factory::generate_key_ec(traits::EC::KeyGroup::P256);
         REQUIRE(keypair != nullptr);
-        REQUIRE_NOTHROW(key.assign(keypair));
+        REQUIRE_NOTHROW(key.assign(keypair, ResourceOwnership::Transfer));
         REQUIRE(key.bit_length() == 256);
     }
     #endif
@@ -323,7 +323,7 @@ TEST_CASE_METHOD(KeyTestFixture, "Key error conditions", "[Key][error]") {
     }
 
     SECTION("Assign null key") {
-        REQUIRE_THROWS_AS(key.assign(nullptr), error::key::InvalidArgumentError);
+        REQUIRE_THROWS_AS(key.assign(nullptr, ResourceOwnership::Default), error::key::InvalidArgumentError);
     }
 
     SECTION("Copy null key") {


### PR DESCRIPTION
Enhances type safety and resource management by:
- Unify ownership semantics with `ResourceOwnership` enum
- Standardize constructor interfaces across `Key`, `PrivateKey`, `Certificate` and `CertificateName` classes
- Fix potential memory leaks in:
  a. `Key::assign`
  b. `Certificate::pubkey`
  c. `Certificate::set_pubkey`
  d. `CertificateRequest::pubkey`
  e. `CertificateRequest::set_pubkey`
  f. `CertificateName` copy ctor

The changes make ownership transfer more explicit and type-safe.
